### PR TITLE
Add suppression flag to fsockopen call to quiet unnecessary warnings.

### DIFF
--- a/Client/MemcacheClient.php
+++ b/Client/MemcacheClient.php
@@ -107,7 +107,7 @@ class MemcacheClient implements CacheClientInterface
 	{
 		$errno = null;
 		$errstr = null;
-		$fp = fsockopen( $ip, $port, $errno, $errstr, $this->sockttl );
+		$fp = @fsockopen( $ip, $port, $errno, $errstr, $this->sockttl );
 
 		if ( $fp )
 		{


### PR DESCRIPTION
I have added the suppression flag to the fsockopen() call to prevent the noise that these warnings call. This addresses #8.

Please let me know if you have any questions.
Thanks!
