### PR TITLE
Allow user configured default TTL value

### DIFF
--- a/Cache.php
+++ b/Cache.php
@@ -20,6 +20,7 @@ class Cache implements CacheInterface
 
     protected $client = null;
     protected $safe = false;
+    protected $ttl = 300;
 
     /**
      * Prep the cache
@@ -50,6 +51,18 @@ class Cache implements CacheInterface
     public function setContainer($dic)
     {
         $this->dic = $dic;
+    }
+
+    /**
+     * Change the default lifetime of the data (default: 300 seconds - five minutes)
+     *
+     * @param int $ttl
+     * @access public
+     * @return void
+     */
+    public function setTtl($ttl)
+    {
+        $this->ttl = $ttl;
     }
 
     /**
@@ -89,12 +102,14 @@ class Cache implements CacheInterface
      *
      * @param string $key A unique key to identify the data you want to store
      * @param string $value The value you want to store in the cache
-     * @param int $ttl Optional: Lifetime of the data (default: 300 seconds - five minutes)
+     * @param int $ttl Optional: Lifetime of the data
      * @access public
      * @return mixed Whatever the CacheClientObject returns, or false.
      */
-    public function set($key, $value, $ttl = 300)
+    public function set($key, $value, $ttl = null)
     {
+        $ttl = (null !== $ttl) ? $ttl : $this->ttl;
+
         if ($this->isSafe() && !empty($key)) {
             return $this->client->set($key, $value, $ttl);
         }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Add it to your AppKernel:
 
 Configure your server list in parameters.ini:
 
-    beryllium_cache.client.servers["127.0.0.1"] = 11211 
+    beryllium_cache.client.servers["127.0.0.1"] = 11211
 
 Or for parameters.yml:
 
@@ -67,12 +67,20 @@ Or for parameters.yml:
         ...
         beryllium_cache.client.servers: { "localhost": 11211 }
 
+If you want to change the default cache TTL value (300 seconds) you can
+add this to your parameters.yml:
+
+    parameters:
+        ...
+        beryllium_cache.default_ttl: 86400
+
+
 If you plan on using local UNIX sockets, GitHub user gierschv has contributed the ability to do this:
 
     beryllium_cache.client.servers["unix:///tmp/mc.sock"]=""
 
 And then you should be good to go:
-  
+
     $this->get( 'beryllium_cache' )->set( 'key', 'value', $ttl );
     $this->get( 'beryllium_cache' )->get( 'key' );
 
@@ -104,7 +112,7 @@ Help is available, although brief:
 
     app/console help cacheclient:stats
 
-## The Future 
+## The Future
 
 Currently there aren't any unit or functional tests. So that needs to be worked on.
 
@@ -116,10 +124,10 @@ Beyond that, who knows what the future might hold.
 
 ## Additional Resources
 
-MySQL InnoDB+Memcached API: 
+MySQL InnoDB+Memcached API:
 
 * http://blogs.innodb.com/wp/2011/04/get-started-with-innodb-memcached-daemon-plugin/
 
-Amazon ElastiCache: 
+Amazon ElastiCache:
 
 * http://aws.amazon.com/elasticache/

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,9 +4,10 @@ parameters:
     beryllium_cache.client.memcache.class: Memcache
     beryllium_cache.client.servers: { 127.0.0.1 : 11211 }
     beryllium_cache.client.prefix: ''
+    beryllium_cache.default_ttl: 300
 
 services:
-    beryllium_cache.client.memcache: 
+    beryllium_cache.client.memcache:
       class: %beryllium_cache.client.memcache.class%
     beryllium_cache.client:
       class: %beryllium_cache.client.class%
@@ -19,3 +20,4 @@ services:
         calls:
           - [ setContainer, [ @service_container ] ]
           - [ setClient, [ @beryllium_cache.client ] ]
+          - [ setTtl, [ %beryllium_cache.default_ttl% ] ]


### PR DESCRIPTION
Hi,

This allows default TTL value to be set as a parameter, saves specifying your own TTL on every set() call.

Cheers.

Gez
