### PR TITLE
Update dependencies to allow Symfony 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require":
     {
       "php": ">=5.3.0",
-      "symfony/console": "2.3.*",
-      "symfony/framework-bundle": "2.3.*"
+      "symfony/console": "~2.3",
+      "symfony/framework-bundle": "~2.3"
     },
     "autoload":
     {


### PR DESCRIPTION
Should be safe to loosen up the Symfony dependencies (http://symfony.com/doc/current/contributing/community/releases.html#backward-compatibility).  I've not had any issues running it against 2.4.
